### PR TITLE
Switched to using MySQL connections pool

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -26,11 +26,18 @@ function connect(options) {
 
   if (activeBackend === 'mysql') {
     // Save a reference to the MySQL client object for later use.
-    activeDb = mysql.createConnection(options);
+    activeDb = mysql.createPool(options);
 
     if (activeDb !== null) {
-      activeDb.on('error', function (err) {
-        console.log(err);
+      activeDb
+        .on('acquire', function (connection) {
+        console.log('Connection %d acquired', connection.threadId);
+      })
+        .on('enqueue', function () {
+        console.log('Waiting for available connection slot');
+      })
+        .on('release', function (connection) {
+        console.log('Connection %d released', connection.threadId);
       });
     }
   }


### PR DESCRIPTION
To handle errors like https://github.com/cfdp/opeka/issues/47#issuecomment-288065044. As mentioned at https://github.com/mysqljs/mysql/blob/master/Readme.md#server-disconnects:

> With Pool, disconnected connections will be removed from the pool freeing up space for a new connection to be created on the next getConnection call.
